### PR TITLE
Kansa debug entrypoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,17 @@ BASE_CFG = config/docker-compose.base.yaml
 DEV_CFG = config/docker-compose.dev.yaml
 PROD_CFG = config/docker-compose.prod.yaml
 PROD_CFG_TMPL = config/docker-compose.prod-template.yaml
+DEBUG_CFG = config/docker-compose.debug.yml
 
 DC = docker-compose -f $(BASE_CFG) -f $(DEV_CFG) -p $(NAME)
 
 start:
 	$(DC) up --build
+
+debug:
+	$(DC) -f $(DEBUG_CFG) up --build
+	# TODO /Debugger listening on ws://0.0.0.0:9229/(\w+-\w+-\w+-\w+-\w+)/
+	# chrome-devtools://devtools/bundled/js_app.html?ws=localhost:9229/$1
 
 start-detached:
 	$(DC) up -d --build

--- a/config/docker-compose.debug.yml
+++ b/config/docker-compose.debug.yml
@@ -1,0 +1,8 @@
+version: '2'
+
+# Adds debugger to kansa
+services:
+  kansa:
+    entrypoint: ./wait-for-it.sh postgres:5432 -- node --inspect=0.0.0.0 server.js
+    ports:
+      - "9229:9229"


### PR DESCRIPTION
As this codebase is rather dense and requires a lot of setup to have a single stood up server, it's important to get a feel for how the code is executing.

This PR introduces a new make target to allow you to open an interactive debugger against your local kansa to inspect the running code. This works for OSX.

To get a debugger open

1. Run `make debug` from the root of the project
2. Follow logs with `docker logs -f kansa_kansa_1 | grep "Debugger listening on ws://"`
3. Take the application UUID printed out and substitute it into this URL in chrome:

chrome-devtools://devtools/bundled/js_app.html?ws=localhost:9229/e565eb6d-48ff-4dbe-8070-b6de4c30e2bd

![screen shot 2018-09-04 at 6 36 26 pm](https://user-images.githubusercontent.com/45738/45014108-78d7c600-b071-11e8-8373-dc09c65bb5ed.png)

From there, you'll have an interactive debugging session where you can set breakpoints, watch for `console.log` printouts and more.

This is a WIP PR asking for early feedback. 

TODO

- Update documentation to reflect this
- Investigate pushing docker-compose into the background and printing the URL using [( tail -f -n0 logfile.log & ) | grep -q "Debugger listening on ws://""
](https://superuser.com/a/900134/20801)
