### PR TITLE
Split site-selection endpoints to their own module

### DIFF
--- a/common/README.md
+++ b/common/README.md
@@ -44,12 +44,14 @@ server start.
 ## Errors
 
 ```js
-const { AuthError, InputError } = require('@kansa/common/errors')
+const { AuthError, InputError, NotFoundError } = require('@kansa/common/errors')
 ```
 
 ### `new AuthError(message: string)`
 
 ### `new InputError(message: string)`
+
+### `new NotFoundError(message: string)`
 
 Handled by the server's error handling. May also have their `status` set.
 

--- a/common/errors.js
+++ b/common/errors.js
@@ -13,4 +13,12 @@ function InputError(message = 'Input error') {
 }
 InputError.prototype = new Error()
 
-module.exports = { AuthError, InputError }
+function NotFoundError(message = 'Not Found') {
+  this.name = 'NotFoundError'
+  this.message = message
+  this.status = 404
+  this.stack = new Error().stack
+}
+NotFoundError.prototype = new Error()
+
+module.exports = { AuthError, InputError, NotFoundError }

--- a/config/database/dev-people.sql
+++ b/config/database/dev-people.sql
@@ -42,6 +42,7 @@ ALTER SEQUENCE member_number_seq RESTART WITH 42;
 CREATE FUNCTION reset_test_users() RETURNS void AS $$
 BEGIN
   UPDATE keys SET key='key', expires=NULL WHERE email='admin@example.com';
+  UPDATE keys SET key='key', expires=NULL WHERE email='site-select@example.com';
   UPDATE keys SET key='key', expires='2017-08-13' WHERE email='expired@example.com';
 END;
 $$ LANGUAGE plpgsql;

--- a/config/kansa.yaml
+++ b/config/kansa.yaml
@@ -54,6 +54,9 @@ modules:
   # Art show management
   raami: false
 
+  # Site selection token management
+  siteselect: true
+
   # Invite generator for a Slack organisation
   slack:
     #org: worldcon75

--- a/config/siteselection/ballot-data.js
+++ b/config/siteselection/ballot-data.js
@@ -1,14 +1,16 @@
-function ballotData({
-  member_number,
-  legal_name,
-  email,
-  city,
-  state,
-  country,
-  badge_name,
-  paper_pubs,
+function ballotData(
+  {
+    member_number,
+    legal_name,
+    email,
+    city,
+    state,
+    country,
+    badge_name,
+    paper_pubs
+  },
   token
-}) {
+) {
   const address = (paper_pubs && paper_pubs.address.split(/[\n\r]+/)) || ['']
   return {
     info: {
@@ -24,7 +26,7 @@ function ballotData({
       City: city || '',
       Country: paper_pubs ? paper_pubs.country : country || '',
       'Membership number': member_number || '........',
-      'Voting token': token,
+      'Voting token': token || '',
       'E-mail': email,
       'State/Province/Prefecture': state || '',
       'Badge name': badge_name || '',

--- a/integration-tests/test/hugo-nominations.spec.js
+++ b/integration-tests/test/hugo-nominations.spec.js
@@ -10,6 +10,8 @@ const host = 'localhost:4430'
 const admin = request.agent(`https://${host}`, { ca })
 const nominator = request.agent(`https://${host}`, { ca })
 
+if (!config.modules.hugo) return
+
 const randomString = () => (Math.random().toString(36) + '0000000').slice(2, 7)
 
 describe('Hugo nominations', () => {

--- a/integration-tests/test/siteselect.spec.js
+++ b/integration-tests/test/siteselect.spec.js
@@ -1,11 +1,15 @@
 const assert = require('assert')
 const fs = require('fs')
 const request = require('supertest')
+const YAML = require('yaml').default
 
+const config = YAML.parse(fs.readFileSync('../config/kansa.yaml', 'utf8'))
 const ca = fs.readFileSync('../proxy/ssl/localhost.cert', 'utf8')
 const host = 'localhost:4430'
 const admin = request.agent(`https://${host}`, { ca })
 const member = request.agent(`https://${host}`, { ca })
+
+if (!config.modules.siteselect) return
 
 describe('Site selection', () => {
   let id = null
@@ -40,12 +44,12 @@ describe('Site selection', () => {
 
   it('member: get own ballot', () =>
     member
-      .get(`/api/people/${id}/ballot`)
+      .get(`/api/siteselect/${id}/ballot`)
       .expect(200)
       .expect('Content-Type', 'application/pdf'))
 
   it("member: fail to get others' ballot", () =>
-    member.get(`/api/people/${id - 1}/ballot`).expect(401))
+    member.get(`/api/siteselect/${id - 1}/ballot`).expect(401))
 
   it('member: fail to list tokens', () =>
     member.get(`/api/siteselect/tokens.json`).expect(401))
@@ -55,7 +59,7 @@ describe('Site selection', () => {
 
   it('admin: get member ballot', () =>
     admin
-      .get(`/api/people/${id}/ballot`)
+      .get(`/api/siteselect/${id}/ballot`)
       .expect(200)
       .expect('Content-Type', 'application/pdf'))
 

--- a/integration-tests/test/siteselect.spec.js
+++ b/integration-tests/test/siteselect.spec.js
@@ -38,14 +38,42 @@ describe('Site selection', () => {
       })
   })
 
-  it('member: get own ballot', () => {
-    return member
+  it('member: get own ballot', () =>
+    member
       .get(`/api/people/${id}/ballot`)
       .expect(200)
-      .expect('Content-Type', 'application/pdf')
-  })
+      .expect('Content-Type', 'application/pdf'))
 
-  it("member: fail to get others' ballot", () => {
-    return member.get(`/api/people/${id - 1}/ballot`).expect(401)
-  })
+  it("member: fail to get others' ballot", () =>
+    member.get(`/api/people/${id - 1}/ballot`).expect(401))
+
+  it('member: fail to list tokens', () =>
+    member.get(`/api/siteselect/tokens.json`).expect(401))
+
+  it('member: fail to list voters', () =>
+    member.get(`/api/siteselect/voters.json`).expect(401))
+
+  it('admin: list tokens as JSON', () =>
+    admin
+      .get(`/api/siteselect/tokens.json`)
+      .expect(200)
+      .expect(res => assert(Array.isArray(res.body))))
+
+  it('admin: list tokens as CSV', () =>
+    admin
+      .get(`/api/siteselect/tokens.csv`)
+      .expect(200)
+      .expect('Content-Type', /text\/csv/))
+
+  it('admin: list voters as JSON', () =>
+    admin
+      .get(`/api/siteselect/voters.json`)
+      .expect(200)
+      .expect(res => assert(Array.isArray(res.body))))
+
+  it('admin: list voters as CSV', () =>
+    admin
+      .get(`/api/siteselect/voters.csv`)
+      .expect(200)
+      .expect('Content-Type', /text\/csv/))
 })

--- a/integration-tests/test/siteselect.spec.js
+++ b/integration-tests/test/siteselect.spec.js
@@ -53,6 +53,12 @@ describe('Site selection', () => {
   it('member: fail to list voters', () =>
     member.get(`/api/siteselect/voters.json`).expect(401))
 
+  it('admin: get member ballot', () =>
+    admin
+      .get(`/api/people/${id}/ballot`)
+      .expect(200)
+      .expect('Content-Type', 'application/pdf'))
+
   it('admin: list tokens as JSON', () =>
     admin
       .get(`/api/siteselect/tokens.json`)

--- a/integration-tests/test/siteselect.spec.js
+++ b/integration-tests/test/siteselect.spec.js
@@ -1,0 +1,51 @@
+const assert = require('assert')
+const fs = require('fs')
+const request = require('supertest')
+
+const ca = fs.readFileSync('../proxy/ssl/localhost.cert', 'utf8')
+const host = 'localhost:4430'
+const admin = request.agent(`https://${host}`, { ca })
+const member = request.agent(`https://${host}`, { ca })
+
+describe('Site selection', () => {
+  let id = null
+  before(() => {
+    const email = 'member@example.com'
+    const key = 'key'
+    return member
+      .get('/api/login')
+      .query({ email, key })
+      .expect('set-cookie', /w75/)
+      .expect(200, { status: 'success', email })
+      .then(() => member.get('/api/user'))
+      .then(res => {
+        id = res.body.people[0].id
+        assert.equal(typeof id, 'number')
+      })
+  })
+
+  before(() => {
+    const email = 'site-select@example.com'
+    const key = 'key'
+    return admin
+      .get('/api/login')
+      .query({ email, key })
+      .expect('set-cookie', /w75/)
+      .expect(200, { status: 'success', email })
+      .then(() => admin.get('/api/user'))
+      .then(res => {
+        assert.notEqual(res.body.roles.indexOf('siteselection'), -1)
+      })
+  })
+
+  it('member: get own ballot', () => {
+    return member
+      .get(`/api/people/${id}/ballot`)
+      .expect(200)
+      .expect('Content-Type', 'application/pdf')
+  })
+
+  it("member: fail to get others' ballot", () => {
+    return member.get(`/api/people/${id - 1}/ballot`).expect(401)
+  })
+})

--- a/modules/siteselect/lib/admin.js
+++ b/modules/siteselect/lib/admin.js
@@ -1,28 +1,7 @@
-const randomstring = require('randomstring')
 const { InputError } = require('@kansa/common/errors')
+const { parseToken } = require('./token')
 
-class Siteselect {
-  static generateToken() {
-    return randomstring.generate({
-      length: 6,
-      charset: 'ABCDEFHJKLMNPQRTUVWXY0123456789'
-    })
-  }
-
-  static parseToken(token) {
-    return (
-      token &&
-      token
-        .trim()
-        .toUpperCase()
-        .replace(/G/g, '6')
-        .replace(/I/g, '1')
-        .replace(/O/g, '0')
-        .replace(/S/g, '5')
-        .replace(/Z/g, '2')
-    )
-  }
-
+class Admin {
   constructor(db) {
     this.db = db
     this.findToken = this.findToken.bind(this)
@@ -33,7 +12,7 @@ class Siteselect {
   }
 
   findToken(req, res, next) {
-    const token = Siteselect.parseToken(req.params.token)
+    const token = parseToken(req.params.token)
     if (!token) return res.status(404).json({ error: 'not found' })
     this.db
       .oneOrNone(`SELECT * FROM token_lookup WHERE token=$1`, token)
@@ -85,7 +64,7 @@ class Siteselect {
 
   vote(req, res, next) {
     const { id } = req.params
-    const token = Siteselect.parseToken(req.body.token)
+    const token = parseToken(req.body.token)
     let { voter_name, voter_email } = req.body
     this.db
       .task(dbTask =>
@@ -133,4 +112,4 @@ class Siteselect {
   }
 }
 
-module.exports = Siteselect
+module.exports = Admin

--- a/modules/siteselect/lib/admin.js
+++ b/modules/siteselect/lib/admin.js
@@ -1,4 +1,4 @@
-const { InputError } = require('@kansa/common/errors')
+const { InputError, NotFoundError } = require('@kansa/common/errors')
 const { parseToken } = require('./token')
 
 class Admin {
@@ -13,19 +13,19 @@ class Admin {
 
   findToken(req, res, next) {
     const token = parseToken(req.params.token)
-    if (!token) return res.status(404).json({ error: 'not found' })
+    if (!token) return next(new NotFoundError())
     this.db
       .oneOrNone(`SELECT * FROM token_lookup WHERE token=$1`, token)
       .then(data => {
-        if (data) res.json(data)
-        else res.status(404).json({ error: 'not found' })
+        if (!data) throw new NotFoundError()
+        res.json(data)
       })
       .catch(next)
   }
 
   findVoterTokens(req, res, next) {
     const { id } = req.params
-    if (!id) return res.status(404).json({ error: 'not found' })
+    if (!id) return next(new NotFoundError())
     this.db
       .any(
         `

--- a/modules/siteselect/lib/ballot.js
+++ b/modules/siteselect/lib/ballot.js
@@ -1,5 +1,5 @@
 const fetch = require('node-fetch')
-const { AuthError, InputError } = require('@kansa/errors')
+const { AuthError, InputError } = require('@kansa/common/errors')
 
 // source is at /config/siteselection/ballot-data.js
 const ballotData = require('/ss-ballot-data')
@@ -15,7 +15,6 @@ class Ballot {
     if (isNaN(id) || id <= 0)
       return next(new InputError('Invalid id parameter'))
     const { user } = req.session
-    if (!user || !user.email) return next(new AuthError())
     return this.db
       .task(async t => {
         let pq = `SELECT

--- a/modules/siteselect/lib/router.js
+++ b/modules/siteselect/lib/router.js
@@ -1,0 +1,23 @@
+const express = require('express')
+const { isSignedIn, hasRole } = require('@kansa/common/auth-user')
+const Admin = require('./admin')
+const Ballot = require('./ballot')
+
+module.exports = db => {
+  const router = express.Router()
+
+  const ballot = new Ballot(db)
+  router.get('/:id/ballot', isSignedIn, ballot.getBallot)
+
+  const admin = new Admin(db)
+  router.use('/tokens*', hasRole('siteselection'))
+  router.get('/tokens.:fmt', admin.getTokens)
+  router.get('/tokens/:token', admin.findToken)
+
+  router.use('/voters*', hasRole('siteselection'))
+  router.get('/voters.:fmt', admin.getVoters)
+  router.get('/voters/:id', admin.findVoterTokens)
+  router.post('/voters/:id', admin.vote)
+
+  return router
+}

--- a/modules/siteselect/lib/token.js
+++ b/modules/siteselect/lib/token.js
@@ -1,0 +1,24 @@
+const randomstring = require('randomstring')
+
+function generateToken() {
+  return randomstring.generate({
+    length: 6,
+    charset: 'ABCDEFHJKLMNPQRTUVWXY0123456789'
+  })
+}
+
+function parseToken(token) {
+  return (
+    token &&
+    token
+      .trim()
+      .toUpperCase()
+      .replace(/G/g, '6')
+      .replace(/I/g, '1')
+      .replace(/O/g, '0')
+      .replace(/S/g, '5')
+      .replace(/Z/g, '2')
+  )
+}
+
+module.exports = { generateToken, parseToken }

--- a/modules/siteselect/package.json
+++ b/modules/siteselect/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@kansa/siteselect",
+  "version": "1.0.0",
+  "description": "Worldcon Site Selection for Kansa",
+  "private": true,
+  "license": "Apache-2.0",
+  "repository": "maailma/kansa",
+  "main": "lib/router.js",
+  "peerDependencies": {
+    "@kansa/common": "1.x",
+    "express": "4.x",
+    "node-fetch": "*",
+    "randomstring": "1.x"
+  }
+}

--- a/server/lib/people/router.js
+++ b/server/lib/people/router.js
@@ -2,7 +2,6 @@ const express = require('express')
 const { isSignedIn, hasRole, matchesId } = require('@kansa/common/auth-user')
 
 const badge = require('../badge')
-const Ballot = require('../ballot')
 
 const addPerson = require('./add')
 const { getPerson, getPrevNames, getPersonLog } = require('./get')
@@ -77,8 +76,6 @@ module.exports = (db, ctx) => {
       .catch(next)
   })
 
-  const ballot = new Ballot(db)
-  router.get('/:id/ballot', ballot.getBallot)
   router.get('/:id/badge', badge.getBadge)
   router.get('/:id/barcode.:fmt', badge.getBarcode)
   router.post('/:id/print', hasRole('member_admin'), badge.logPrint)

--- a/server/lib/router.js
+++ b/server/lib/router.js
@@ -7,7 +7,6 @@ const peopleRouter = require('./people/router')
 const adminRouter = require('./admin/router')
 const getConfig = require('./get-config')
 const Purchase = require('./purchase')
-const Siteselect = require('./siteselect')
 const userRouter = require('./user/router')
 
 module.exports = (db, ctx) => {
@@ -43,14 +42,6 @@ module.exports = (db, ctx) => {
   router.use('/members', ar.membersRouter)
   router.use('/people', ar)
   router.use('/people', peopleRouter(db, ctx))
-
-  const siteselect = new Siteselect(db)
-  router.use('/siteselect', hasRole('siteselection'))
-  router.get('/siteselect/tokens.:fmt', siteselect.getTokens)
-  router.get('/siteselect/tokens/:token', siteselect.findToken)
-  router.get('/siteselect/voters.:fmt', siteselect.getVoters)
-  router.get('/siteselect/voters/:id', siteselect.findVoterTokens)
-  router.post('/siteselect/voters/:id', siteselect.vote)
 
   return router
 }

--- a/server/lib/types/payment.js
+++ b/server/lib/types/payment.js
@@ -1,7 +1,7 @@
 const Stripe = require('stripe')
 const config = require('@kansa/common/config')
 const { InputError } = require('@kansa/common/errors')
-const { generateToken } = require('../siteselect')
+const { generateToken } = require('./token')
 
 function checkData(shape, data) {
   const missing = shape

--- a/server/lib/types/token.js
+++ b/server/lib/types/token.js
@@ -1,0 +1,24 @@
+const randomstring = require('randomstring')
+
+function generateToken() {
+  return randomstring.generate({
+    length: 6,
+    charset: 'ABCDEFHJKLMNPQRTUVWXY0123456789'
+  })
+}
+
+function parseToken(token) {
+  return (
+    token &&
+    token
+      .trim()
+      .toUpperCase()
+      .replace(/G/g, '6')
+      .replace(/I/g, '1')
+      .replace(/O/g, '0')
+      .replace(/S/g, '5')
+      .replace(/Z/g, '2')
+  )
+}
+
+module.exports = { generateToken, parseToken }


### PR DESCRIPTION
This builds on #60, and should only be merged after that. This is a bit of a work-in-progress, so this branch may get rebased on occasionally.

The REST API changes a little here, as what used to be `GET people/:id/ballot` is now `GET siteselect/:id/ballot`, and it no longer requires that a token has been purchased (this is the endpoint that returns a form-filled PDF ballot). Site-selection admins may now also fetch a member's ballot.

In order for the (newly added) tests to pass consistently, the `reset_test_users()` postgres function now also sets the `site-select@example.com` user's key.

There are a couple of integration points for site-selection actions that are not included in this module (token generation, transactional email contents, `/config/siteselection`). Not sure whether those should be pulled in here as well, and if so, how exactly.